### PR TITLE
fixes #14; fix compilation issues for latest nim release

### DIFF
--- a/asynctools.nimble
+++ b/asynctools.nimble
@@ -1,7 +1,7 @@
 # Package
-version     = "0.1.0"
+version     = "0.1.1"
 author      = "Eugene Kabanov"
 description = "Various asynchronous tools for Nim"
 license     = "MIT"
 # Deps
-requires "nim >= 0.14.2"
+requires "nim >= 0.19.4"

--- a/asynctools/asyncdns.nim
+++ b/asynctools/asyncdns.nim
@@ -22,7 +22,7 @@ const
   PACKETSZ = 512
 
 type
-  uncheckedArray {.unchecked.} [T] = array[0..100_000, T]
+  uncheckedArray [T] = UncheckedArray[T]
   AsyncAddrInfo* = distinct AddrInfo
 
 when defined(windows):
@@ -658,7 +658,7 @@ else:
             psin_len[] = cast[uint8](sizeof(Sockaddr_in))
 
           var addrp = cast[ptr Sockaddr_in](addr sockArr[ai])
-          addrp.sin_family = toInt(domain)
+          addrp.sin_family = TSa_Family(toInt(domain))
           addrp.sin_port = nativesockets.ntohs(cast[uint16](port))
           copyMem(addr addrp.sin_addr, record.rdata, 4)
           if k + 1 < count:
@@ -678,7 +678,7 @@ else:
             psin_len[] = cast[uint8](sizeof(Sockaddr_in6))
 
           var addrp = cast[ptr Sockaddr_in6](addr sockArr[ai])
-          addrp.sin6_family = toInt(domain)
+          addrp.sin6_family = TSa_Family(toInt(domain))
           addrp.sin6_port = nativesockets.ntohs(cast[uint16](port))
           copyMem(addr addrp.sin6_addr, record.rdata, 4 * 4)
           if k + 1 < count:
@@ -721,8 +721,6 @@ else:
         raise newException(ValueError, "No address records for domain!")
       of rtypeError:
         raise newException(ValueError, "Wrong record type in response!")
-      else:
-        raise newException(ValueError, "Unknown error!")
 
 proc free*(aip: ptr AsyncAddrInfo) =
   dealloc(cast[pointer](aip))


### PR DESCRIPTION
* fixes #14
/cc @cheatfate after this PR, `nimble test` works for httpbeast /cc @dom96
before this PR, it was failing with:
```
/Users/timothee/.nimble/pkgs/asynctools-0.1.0/asynctools/asyncdns.nim(25, 20) Error: invalid pragma: unchecked
```
+ other errors

## note
supersedes part of https://github.com/cheatfate/asynctools/pull/15 (i'm using TSa_Family instead of uint16, which seems better since that's how it's declared in code, eg: `lib/posix/posix_other.nim:390:17:    sa_family*: TSa_Family`), but other parts of #15 are still needed so maybe @treeform can update his PR (note: that PR has been waited on since october 2018...)


