### PR TITLE
fix for Nim 1.2 + explain readInto EOF semantics

### DIFF
--- a/asynctools/asyncpipe.nim
+++ b/asynctools/asyncpipe.nim
@@ -87,7 +87,7 @@ when defined(nimdoc):
     ## into ``data``, which must at least be of that size.
     ##
     ## Returned future will complete once all the data requested is read or
-    ## part of the data has been read.
+    ## part of the data has been read. A future with value 0 means end of file.
 
   proc asyncWrap*(readHandle: Handle|cint = 0,
                   writeHandle: Handle|cint = 0): AsyncPipe =

--- a/asynctools/asyncpipe.nim
+++ b/asynctools/asyncpipe.nim
@@ -116,6 +116,7 @@ else:
 
   when defined(windows):
     import winlean
+    import asyncpty
   else:
     import posix
 


### PR DESCRIPTION
Fix an error in Nim 1.2 on Windows:

    asynctools\asyncpipe.nim(260, 16) Error: undeclared identifier: 'PCustomOverlapped'

Also, it took me suuuuper long to find out how to detect that asyncpipe.readInto encountered an EOF on Windows... so I thought it could be nice to add an explicit explanation in the docs...