### PR TITLE
fix: fix missing gcsafe pragma on wakeupAll proc

### DIFF
--- a/asynctools/asyncsync.nim
+++ b/asynctools/asyncsync.nim
@@ -151,7 +151,7 @@ proc fire*(event: AsyncEv) =
   ## Set the internal flag of ``event`` to `true`. All tasks waiting for it
   ## to become `true` are awakened. Task that call `wait()` once the flag is
   ## `true` will not block at all.
-  proc wakeupAll() =
+  proc wakeupAll() {.gcsafe.} =
     if len(event.waiters) > 0:
       var w = event.waiters.popFirst()
       if not w.finished:


### PR DESCRIPTION
Without it, I couldn't compile and got this error:
```
/home/jonathan/dev/nim-status-client/vendor/asynctools/asynctools/asyncsync.nim(159, 15) Error: type mismatch: got <proc (){.closure.}>
but expected one of: 
proc callSoon(cbproc: proc () {.gcsafe.})
  first type mismatch at position: 1
  required type for cbproc: proc (){.closure, gcsafe.}
  but expression 'wakeupAll' is of type: proc (){.closure.}
  This expression is not GC-safe. Annotate the proc with {.gcsafe.} to get extended error information.

expression: callSoon(wakeupAll)
```