### PR TITLE
Few fixes to get `asyncipc` working with devel on windows

### DIFF
--- a/asynctools/asyncipc.nim
+++ b/asynctools/asyncipc.nim
@@ -130,7 +130,6 @@ elif defined(windows):
       ioPort: Handle
       handles: HashSet[AsyncFD]
     HackDispatcher = ptr HackDispatcherImpl
-    Dispatcher = HackDispatcher | PDispatcher
 
   proc openEvent(dwDesiredAccess: Dword, bInheritHandle: WINBOOL,
                  lpName: WideCString): Handle
@@ -143,7 +142,7 @@ elif defined(windows):
   proc interlockedAnd(a: ptr int32, b: int32)
        {.importc: "_InterlockedAnd", header: "intrin.h".}
 
-  proc getCurrentDispatcher(): Dispatcher =
+  proc getCurrentDispatcher(): auto =
     when defined(nimv2):
       # New runtime will run into segfault if using HackDispatcher, but old versions of Nim require
       # HackDispatcher so we can access some internal fields.
@@ -153,12 +152,9 @@ elif defined(windows):
     else:
       cast[HackDispatcher](getGlobalDispatcher())
 
-  template getIoHandler(p: Dispatcher): Handle =
+  template getIoHandler(p: HackDispatcher): Handle =
     ## Returns the IO handle for a dispatcher.
-    when p is PDispatcher:
-      p.getIoHandler()
-    else:
-      p.ioPort
+    p.ioPort
 
   proc `$`*(ipc: AsyncIpc): string =
     if ipc.handleMap == Handle(0):

--- a/asynctools/asyncipc.nim
+++ b/asynctools/asyncipc.nim
@@ -183,11 +183,10 @@ elif defined(windows):
     let mapSize = size + mapMinSize
 
     doAssert(size > mapMinSize)
-
     let handleMap = createFileMappingW(INVALID_HANDLE_VALUE,
                                        cast[pointer](addr sa),
                                        PAGE_READWRITE, 0, mapSize.Dword,
-                                       cast[pointer](mapName))
+                                       cast[pointer](WideCString(mapName)))
     if handleMap == 0:
       raiseOSError(osLastError())
     var eventChange = createEvent(addr sa, 0, 0, addr nameChange[0])
@@ -267,7 +266,7 @@ elif defined(windows):
       interlockedOr(cast[ptr int32](data), 1)
 
     if register:
-      let p = getCurrentDispatcher()
+      let p = getGlobalDispatcher()
       p.handles.incl(AsyncFD(eventChange))
 
     result = AsyncIpcHandle(
@@ -285,7 +284,7 @@ elif defined(windows):
       interlockedAnd(cast[ptr int32](ipch.data), not(1))
 
     if unregister:
-      let p = getCurrentDispatcher()
+      let p = getGlobalDispatcher()
       p.handles.excl(AsyncFD(ipch.eventChange))
 
     if unmapViewOfFile(ipch.data) == 0:


### PR DESCRIPTION
Closes #43  

 - First fix was to make sure the object is `WideCString` first before casting to pointer so that we are actually accessing the data (On devel this calls a converter which returns the internal data)

 - I was running into a nil access error on ORC which I fixed by using the stdlib `getGlobalDispatcher()` instead