### PR TITLE
Make `pipeName` be `WideCStringObj` so the data isn't deleted too early

### DIFF
--- a/asynctools/asyncpipe.nim
+++ b/asynctools/asyncpipe.nim
@@ -160,7 +160,7 @@ else:
     proc createPipe*(register = true): AsyncPipe =
 
       var number = 0'i64
-      var pipeName: WideCString
+      var pipeName: WideCStringObj
       var pipeIn: Handle
       var pipeOut: Handle
       var sa = SECURITY_ATTRIBUTES(nLength: sizeof(SECURITY_ATTRIBUTES).cint,


### PR DESCRIPTION
Issue was brought up with `nimlsp` CI [failing on windows](https://github.com/PMunch/nimlsp/actions/runs/6232716471/job/16916440939#step:7:73)

Investigating it led me to this [section](https://github.com/cheatfate/asynctools/blob/a1a17d06713727d97810cad291e29dd7c672738f/asynctools/asyncpipe.nim#L163-L186) where `pipeName` was becoming garbage by the time it got to line 186. Looking at the arc expansion I saw the internal data was getting deleted too early
```nim
try:
  var number = 0'i64
  var pipeName: WideCString
  var pipeIn: Handle
  var pipeOut: Handle
  var sa = SECURITY_ATTRIBUTES(nLength: 24, lpSecurityDescriptor: nil,
                               bInheritHandle: 1)
  echo ["start loop"]
  block :tmp:
    while true:
      var
        p
        :tmpD_1
        :tmpD_2
      try:
        QueryPerformanceCounter(number)
        p = `&`(r"\\.\pipe\asyncpipe_") do:
          :tmpD_1 = $number
          :tmpD_1
        # Converter is called here which returns the raw data stored
        pipeName = toWideCString(
          :tmpD_2 = newWideCString(p)
          :tmpD_2)
        var openMode = 1074266113'i32
        var pipeMode = 0'i32
        pipeIn = createNamedPipe(pipeName, openMode, pipeMode, 1'i32, 65536'i32,
                                 65536'i32, 1'i32, addr(sa))
        if pipeIn == -1:
          let err = osLastError()
          if (
            not (int32(err) == 231)):
            raiseOSError(err, "")
        else:
          break :tmp
      finally:
        # Destroys the object which deallocs the data which
        # we are still using the pointer to
        `=destroy_1`(:tmpD_2)
        `=destroy`(:tmpD_1)
        `=destroy`(p)
  var openMode_1 = 1048578'i32
```
By keeping a reference to the actual object instead of the pointer inside, it doesn't get destroyed too early