### PR TITLE
Windows pipe creation fix

### DIFF
--- a/asynctools/asyncpipe.nim
+++ b/asynctools/asyncpipe.nim
@@ -160,6 +160,7 @@ else:
     proc createPipe*(register = true): AsyncPipe =
 
       var number = 0'i64
+      var pipeName: string
       var pipeNameWS: WideCString
       var pipeIn: Handle
       var pipeOut: Handle
@@ -167,8 +168,8 @@ else:
                                    lpSecurityDescriptor: nil, bInheritHandle: 1)
       while true:
         QueryPerformanceCounter(number)
-        let p = pipeHeaderName & $number
-        pipeNameWS = newWideCString(p)
+        pipeName = pipeHeaderName & $number
+        pipeNameWS = newWideCString(pipeName)
         var openMode = FILE_FLAG_FIRST_PIPE_INSTANCE or FILE_FLAG_OVERLAPPED or
                        PIPE_ACCESS_INBOUND
         var pipeMode = PIPE_TYPE_BYTE or PIPE_READMODE_BYTE or PIPE_WAIT
@@ -182,6 +183,7 @@ else:
         else:
           break
 
+      pipeNameWS = newWideCString(pipeName)
       var openMode = (FILE_WRITE_DATA or SYNCHRONIZE)
       pipeOut = createFileW(pipeNameWS, openMode, 0, addr(sa), OPEN_EXISTING,
                             FILE_FLAG_OVERLAPPED, 0)

--- a/asynctools/asyncpipe.nim
+++ b/asynctools/asyncpipe.nim
@@ -160,7 +160,7 @@ else:
     proc createPipe*(register = true): AsyncPipe =
 
       var number = 0'i64
-      var pipeName: WideCString
+      var pipeNameWS: WideCString
       var pipeIn: Handle
       var pipeOut: Handle
       var sa = SECURITY_ATTRIBUTES(nLength: sizeof(SECURITY_ATTRIBUTES).cint,
@@ -168,11 +168,11 @@ else:
       while true:
         QueryPerformanceCounter(number)
         let p = pipeHeaderName & $number
-        pipeName = newWideCString(p)
+        pipeNameWS = newWideCString(p)
         var openMode = FILE_FLAG_FIRST_PIPE_INSTANCE or FILE_FLAG_OVERLAPPED or
                        PIPE_ACCESS_INBOUND
         var pipeMode = PIPE_TYPE_BYTE or PIPE_READMODE_BYTE or PIPE_WAIT
-        pipeIn = createNamedPipe(pipeName, openMode, pipeMode, 1'i32,
+        pipeIn = createNamedPipe(pipeNameWS, openMode, pipeMode, 1'i32,
                                  DEFAULT_PIPE_SIZE, DEFAULT_PIPE_SIZE,
                                  1'i32, addr sa)
         if pipeIn == INVALID_HANDLE_VALUE:
@@ -183,7 +183,7 @@ else:
           break
 
       var openMode = (FILE_WRITE_DATA or SYNCHRONIZE)
-      pipeOut = createFileW(pipeName, openMode, 0, addr(sa), OPEN_EXISTING,
+      pipeOut = createFileW(pipeNameWS, openMode, 0, addr(sa), OPEN_EXISTING,
                             FILE_FLAG_OVERLAPPED, 0)
       if pipeOut == INVALID_HANDLE_VALUE:
         let err = osLastError()


### PR DESCRIPTION
This fixes a "file not found" error when creating a pipe under Windows.